### PR TITLE
Docs/include swagger and actuator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.6.4</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -62,8 +67,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>2.6.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>1.6.4</version>
@@ -67,8 +72,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/br/com/letscode/starwarsrebelnetwork/StarWarsRebelNetworkApplication.java
+++ b/src/main/java/br/com/letscode/starwarsrebelnetwork/StarWarsRebelNetworkApplication.java
@@ -1,9 +1,12 @@
 package br.com.letscode.starwarsrebelnetwork;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@OpenAPIDefinition(info = @Info(title = "StarWars API", version = "2.0", description = "Rebels Information"))
 public class StarWarsRebelNetworkApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
Include swagger with the purpose of API documentation and Spring Boot Actuator to generate an health endpoint.

Swagger is available at GET `http://localhost:8080/starwars/swagger-ui/index.html`
Application health is available at GET `http://localhost:8080/starwars/actuator/health`